### PR TITLE
Fixes and new features

### DIFF
--- a/docker_scripts/README.md
+++ b/docker_scripts/README.md
@@ -82,7 +82,7 @@ The `run.sh` script accepts options to be passed to the pysmurf-server's startup
 
 #### Full system, for Software development
 
-A development system is formed by a pysmurf server a pysmurf client. For software development systems, the pysmurf server contains a pysmurf server application provided by the user in a folder called **pysmurf** in the release folder. The release script will do a clone of the `pre-release` branch of the [pysmurf git repository](https://github.com/slaclab/pysmurf). Also, the firmware files are provided by the user by adding them in a folder called **fw** in the release folder.
+A development system is formed by a pysmurf server a pysmurf client. For software development systems, the pysmurf server uses local copies of both rogue and pysmurf; rogue is located in a folder called **rogue**, and pysmurf is located in a folder called **pysmurf** in the release folder. The release script will do a clone of the `pre-release` branch of both the [rogue git repository](https://github.com/slaclab/rogue) and [pysmurf git repository](https://github.com/slaclab/pysmurf). Also, the firmware files are provided by the user by adding them in a folder called **fw** in the release folder.
 
 The server runs in the [pysmurf-server-base docker](https://github.com/slaclab/pysmurf), and pysmurf runs in the the [pysmurf-client docker](https://github.com/slaclab/pysmurf).
 
@@ -111,8 +111,17 @@ The `run.sh` script accepts options to be passed to the pysmurf-server's startup
 
 In the software development mode, if you take a look a the  generated `docker-compose.yml` file you will see that the `command:` line under the `smurf_server` section is commented out. The effect of this, is that when the container is started (by running the `run.sh` script) it will run by default a bash session, instead of starting the pysmurf server. Later one, after you have done your software modification, you can choose to re-enable this line to start the server by default.
 
-When this container is run for the first time, the freshly cloned version of pysmurf need to be compiled. In order to do that, start the container and attach to it (by running `docker attach smurf_server_s<N>`, where *N* depend on which slot you are using). Then go to the pysmurf folder (`/usr/local/src/pysmurf`) and make a clean build:
+When this container is run for the first time, the freshly cloned version of rogue and pysmurf need to be compiled. In order to do that, start the container and attach to it (by running `docker attach smurf_server_s<N>`, where *N* depend on which slot you are using). Then:
+- Go to the rogue folder (`/usr/local/src/rogue`) and make a clean build:
+```
+rm -rf build
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+make -j4
+```
 
+- Then, go to the pysmurf folder (`/usr/local/src/pysmurf`) and make a clean build:
 ```
 rm -rf build
 mkdir build

--- a/docker_scripts/README.md
+++ b/docker_scripts/README.md
@@ -32,17 +32,19 @@ To release an stable system, use **type = system**, with the following arguments
 
 ```
 release-docker.sh -t system
-                  -v|--version <pysmurf_version>
+                  -s|--server-version <pysmurf_server_version>
+                  -p|--client-version <pysmurf_client_version>
                   [-N|--slot <slot_number>]
                   [-o|--output-dir <output_dir>]
                   [-h|--help]
 
-  -v|--version    <pysmurf_version>   : Version of the pysmurf server docker image.
-  -c|--comm-type  <commm_type>        : Communication type with the FPGA (eth or pcie). Defaults to 'eth'.
-  -N|--slot       <slot_number>       : ATCA crate slot number (2-7) (Optional).
-  -o|--output-dir <output_dir>        : Top directory where to release the scripts. Defaults to
-                                        /home/cryo/docker/smurf/stable/<slot_number>/<pysmurf_version>
-  -h|--help                           : Show this message.
+  -s|--server-version <pysmurf_server_version> : Version of the pysmurf-server docker image.
+  -p|--client-version <pysmurf_client_version> : Version of the pysmurf-client docker image.
+  -c|--comm-type      <commm_type>             : Communication type with the FPGA (eth or pcie). Defaults to 'eth'.
+  -N|--slot           <slot_number>            : ATCA crate slot number (2-7) (Optional).
+  -o|--output-dir     <output_dir>             : Top directory where to release the scripts. Defaults to
+                                                 /home/cryo/docker/smurf/stable/<slot_number>/<pysmurf_version>
+  -h|--help                                    : Show this message.
 ```
 
 The slot number is optional:
@@ -55,7 +57,7 @@ The `run.sh` script accepts options to be passed to the pysmurf-server's startup
 
 A development system is formed by a pysmurf server and a pysmurf client. For firmware development systems, the pysmurf server contains the pysmurf server application, while the firmware files are provided by the user by adding them in a folder called **fw** in the release folder.
 
-The server runs in the [pysmurf-server-base docker](https://github.com/slaclab/pysmurf), and pysmurf runs in the the [pysmurf-client docker](https://github.com/slaclab/pysmurf).
+The server runs in the [pysmurf-server-base docker](https://github.com/slaclab/pysmurf), and pysmurf runs in the the [pysmurf-client docker](https://github.com/slaclab/pysmurf). As both of these images are released together, the user only needs to specify one version number, which will be used for both images.
 
 To release a firmware development system, use **type = system-dev-fw**, with the following arguments:
 

--- a/docker_scripts/README.md
+++ b/docker_scripts/README.md
@@ -140,7 +140,7 @@ release-docker.sh -t|--type system3 -s|--smurf2mce-version <smurf2mce_version> -
                   [-N|--slot <slot_number>] [-o|--output-dir <output_dir>] [-h|--help]
 
   -s|--smurf2mce-version <smurf2mce_version> : Version of the smurf2mce docker image.
-  -p|--pysmurf_version   <pysmurf_version>   : Version of the pysmurf docker image.
+  -p|--pysmurf-version   <pysmurf_version>   : Version of the pysmurf docker image.
   -c|--comm-type         <commm_type>        : Communication type with the FPGA (eth or pcie). Defaults to 'eth'.
   -N|--slot              <slot_number>       : ATCA crate slot number (2-7) (Optional).
   -o|--output-dir        <output_dir>        : Top directory where to release the scripts. Defaults to
@@ -165,7 +165,7 @@ release-docker.sh -t|--type system3-dev-fw -s|--smurf2mce-base-version <smurf2mc
                   [-N|--slot <slot_number>] [-o|--output-dir <output_dir>] [-h|--help]
 
   -s|--smurf2mce-base-version <smurf2mce-base_version> : Version of the smurf2mce-base docker image.
-  -p|--pysmurf_version        <pysmurf_version>        : Version of the pysmurf docker image.
+  -p|--pysmurf-version        <pysmurf_version>        : Version of the pysmurf docker image.
   -c|--comm-type              <commm_type>             : Communication type with the FPGA (eth or pcie). Defaults to 'eth'.
   -N|--slot                   <slot_number>            : ATCA crate slot number (2-7) (Optional).
   -o|--output-dir             <output_dir>             : Top directory where to release the scripts. Defaults to
@@ -191,7 +191,7 @@ release-docker.sh -t|--type system3-dev-sw -s|--smurf2mce-base-version <smurf2mc
 
   -s|--smurf2mce-base-version <smurf2mce-base_version> : Version of the smurf2mce-base docker image. Used as a base
                                                          image; smurf2mce will be overwritten by the local copy.
-  -p|--pysmurf_version        <pysmurf_version>        : Version of the pysmurf docker image.
+  -p|--pysmurf-version        <pysmurf_version>        : Version of the pysmurf docker image.
   -c|--comm-type              <commm_type>             : Communication type with the FPGA (eth or pcie). Defaults to 'eth'.
   -N|--slot                   <slot_number>            : ATCA crate slot number (2-7) (Optional).
   -o|--output-dir             <output_dir>             : Top directory where to release the scripts. Defaults to

--- a/docker_scripts/README.md
+++ b/docker_scripts/README.md
@@ -36,6 +36,7 @@ release-docker.sh -t system
                   -p|--client-version <pysmurf_client_version>
                   [-N|--slot <slot_number>]
                   [-o|--output-dir <output_dir>]
+                  [-l|--list-versions]
                   [-h|--help]
 
   -s|--server-version <pysmurf_server_version> : Version of the pysmurf-server docker image.
@@ -44,6 +45,7 @@ release-docker.sh -t system
   -N|--slot           <slot_number>            : ATCA crate slot number (2-7) (Optional).
   -o|--output-dir     <output_dir>             : Top directory where to release the scripts. Defaults to
                                                  /home/cryo/docker/smurf/stable/<slot_number>/<pysmurf_version>
+  -l|--list-versions                           : Print a list of available versions.
   -h|--help                                    : Show this message.
 ```
 
@@ -66,6 +68,7 @@ release-docker.sh -t system-dev-fw
                   -v|--version <pysmurf_version>
                   [-N|--slot <slot_number>]
                   [-o|--output-dir <output_dir>]
+                  [-l|--list-versions]
                   [-h|--help]
 
   -v|--version    <pysmurf_version>   : Version of the pysmurf server docker image.
@@ -73,6 +76,7 @@ release-docker.sh -t system-dev-fw
   -N|--slot       <slot_number>       : ATCA crate slot number (2-7) (Optional).
   -o|--output-dir <output_dir>        : Top directory where to release the scripts. Defaults to
                                         /home/cryo/docker/smurf/dev_fw/<slot_number>/<pysmurf_version>
+  -l|--list-versions                  : Print a list of available versions.
   -h|--help                           : Show this message.
 ```
 
@@ -95,6 +99,7 @@ release-docker.sh -t system-dev-sw
                   -v|--version <pysmurf_version>
                   [-N|--slot <slot_number>]
                   [-o|--output-dir <output_dir>]
+                  [-l|--list-versions]
                   [-h|--help]
 
   -v|--version    <pysmurf_version>   : Version of the pysmurf server docker image.
@@ -102,6 +107,7 @@ release-docker.sh -t system-dev-sw
   -N|--slot       <slot_number>       : ATCA crate slot number (2-7) (Optional).
   -o|--output-dir <output_dir>        : Top directory where to release the scripts. Defaults to
                                         /home/cryo/docker/smurf/dev_sw/<slot_number>/<pysmurf_version>
+  -l|--list-versions                  : Print a list of available versions.
   -h|--help                           : Show this message.
 ```
 
@@ -240,12 +246,13 @@ To release a pysmurf development application, use **type = pysmurf-dev**, with t
 
 ```
 release-docker.sh -t pysmurf-dev -p|--pysmurf_version <pysmurf_version>
-                  [-o|--output-dir <output_dir>] [-h|--help]"
+                  [-o|--output-dir <output_dir>] [-l|--list-versions] [-h|--help]"
 
   -p|--pysmurf_version <pysmurf_version> : Version of the pysmurf docker image. Used as a base.
                                            image; pysmurf will be overwritten by the local copy.
   -o|--output-dir      <output_dir>      : Directory where to release the scripts. Defaults to
                                            /home/cryo/docker/pysmurf/dev.
+  -l|--list-versions                     : Print a list of available versions.
   -h|--help                              : Show this message.
 ```
 
@@ -258,11 +265,13 @@ It run in the [smurf-base docker](https://github.com/slaclab/smurf-base-docker).
 To release an utility application, use **type = utils**, with the following arguments:
 
 ```
-release-docker.sh -t utils -v|--version <smurf_base_version> [-o|--output-dir <output_dir>] [-h|--help]
+release-docker.sh -t utils -v|--version <smurf_base_version> [-o|--output-dir <output_dir>]
+                           [-l|--list-versions] [-h|--help]
 
   -v|--version    <smurf-base_version> : Version of the smurf-base docker image.
   -o|--output-dir <output_dir>         : Directory where to release the scripts. Defaults to
                                          /home/cryo/docker/utils.
+  -l|--list-versions                   : Print a list of available versions.
   -h|--help                            : Show this message.
 ```
 
@@ -275,11 +284,13 @@ It runs in the [smurf-tpg-ioc docker](https://github.com/slaclab/smurf-tpg-ioc-d
 To release a TPG IOCm use **type = tpg**, with the following arguments:
 
 ```
-release-docker.sh -t tpg -v|--version <tpg_version> [-o|--output-dir <output_dir>] [-h|--help]
+release-docker.sh -t tpg -v|--version <tpg_version> [-o|--output-dir <output_dir>]
+                         [-l|--list-versions] [-h|--help]
 
   -v|--version    <tpg_version>   : Version of the smurf-tpg-ioc docker image.
   -o|--output-dir <output_dir>    : Directory where to release the scripts. Defaults to
                                     /home/cryo/docker/tpg.
+  -l|--list-versions              : Print a list of available versions.
   -h|--help                       : Show this message.
 ```
 
@@ -292,11 +303,13 @@ It runs in the [smurf-pcie docker](https://github.com/slaclab/smurf-pcie-docker)
 To release a PCIe utility application use **type = pcie**, with the following arguments:
 
 ```
-release-docker.sh -t pcie -v|--version <pcie_version> [-o|--output-dir <output_dir>] [-h|--help]
+release-docker.sh -t pcie -v|--version <pcie_version> [-o|--output-dir <output_dir>]
+                          [-l|--list-versions] [-h|--help]
 
   -v|--version    <pcie_version> : Version of the smurf-pcie docker image.
   -o|--output-dir <output_dir>   : Directory where to release the scripts. Defaults to
-                                   /home/cryo/docker/pcie
+                                   /home/cryo/docker/pcie.
+  -l|--list-versions             : Print a list of available versions.
   -h|--help                      : Show this message.
 ```
 
@@ -309,11 +322,13 @@ It runs the [smurf-atca-monitor docker](https://github.com/slaclab/smurf-atca-mo
 To release an ATCA monitor application use **type = atca-monitor**, with the following arguments:
 
 ```
-release-docker.sh -t atca-monitor -v|--version <atca-monitor_version> [-o|--output-dir <output_dir>] [-h|--help]
+release-docker.sh -t atca-monitor -v|--version <atca-monitor_version> [-o|--output-dir <output_dir>]
+                                  [-l|--list-versions] [-h|--help]
 
   -v|--version    <atca-monitor_version> : Version of the smurf-atca-monitor docker image.
   -o|--output-dir <output_dir>           : Directory where to release the scripts. Defaults to
                                            /home/cryo/docker/atca-monitor
+  -l|--list-versions                     : Print a list of available versions.
   -h|--help                              : Show this message.
 ```
 

--- a/docker_scripts/common.sh
+++ b/docker_scripts/common.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This script contains common functions to all scrips
+
+# Print all the available tags in a remote repository, pointed by passed argument ($1)
+# Only the tag names are printed, and they are sorted from high to low.
+print_git_tags()
+{
+    git ls-remote --tags --refs $1 | sed -E 's/^[[:xdigit:]]+[[:space:]]+refs\/tags\/(.+)/\1/g' | sort -g -t. -r
+}

--- a/docker_scripts/release-docker.sh
+++ b/docker_scripts/release-docker.sh
@@ -45,7 +45,7 @@ usage()
     echo "                           - pcie           : A PCIe utility application."
     echo "                           - atca-monitor   : An ATCA monitor application."
     echo "  -u|--upgrade [version] : Upgrade these scripts to the specified version. If not version if specified, then the head"
-    echo "                           of the master branch will be used."
+    echo "                           of the master branch will be used. Note: You will be asked for the sudo password."
     echo "  -l|--list-versions     : Print a list of available versions."
     echo "  -h|--help              : Show help message for each application type."
     echo
@@ -101,7 +101,7 @@ update_scripts()
     echo "Updating these scripts to '${tag}'..."
 
     cd ${top_dir}
-    sudo bash -c "git pull && git checkout ${tag}"
+    sudo bash -c "git checkout master && git pull && git checkout ${tag}"
     cd -
 
     echo "Done!."

--- a/docker_scripts/release-docker.sh
+++ b/docker_scripts/release-docker.sh
@@ -3,6 +3,9 @@
 ###############
 # Definitions #
 ###############
+# smurf server scripts git repository
+server_scripts_git_repo=https://github.com/slaclab/smurf-server-scripts.git
+
 # Top directory
 top_dir=$(dirname -- "$(readlink -f $0)")
 
@@ -18,6 +21,8 @@ version=$(cd ${top_dir} && git describe --tags --always --dirty)
 ########################
 # Function definitions #
 ########################
+# Import common functions
+. common.sh
 
 # Usage message
 usage()
@@ -27,19 +32,22 @@ usage()
     echo
     echo "usage: ${script_name} -t|--type <app_type> [-h|--help]"
     echo
-    echo "  -t|--type <app_type> : Type of application to install. Options are:"
-    echo "                         - system         : Full system (stable version) [pysmurf/rogue v4]."
-    echo "                         - system-dev-fw  : Full system (with a development version of FW) [pysmurf/rogue v4]."
-    echo "                         - system-dev-sw  : Full system with a development version of SW and FW [pysmurf/rogue v4]."
-    echo "                         - system3        : Full system (stable version) [smurf2mce/rogue v3]."
-    echo "                         - system3-dev-fw : Full system (with a development version of FW) [smurf2mce/rogue v3]."
-    echo "                         - system3-dev-sw : Full system with a development version of SW and FW [smurf2mce/rogue v3]."
-    echo "                         - pysmurf-dev    : A stand-alone version of pysmurf, in development mode."
-    echo "                         - utils          : A utility system."
-    echo "                         - tpg            : A TPG IOC."
-    echo "                         - pcie           : A PCIe utility application."
-    echo "                         - atca-monitor   : An ATCA monitor application."
-    echo "  -h|--help            : Show help message for each application type."
+    echo "  -t|--type <app_type>   : Type of application to install. Options are:"
+    echo "                           - system         : Full system (stable version) [pysmurf/rogue v4]."
+    echo "                           - system-dev-fw  : Full system (with a development version of FW) [pysmurf/rogue v4]."
+    echo "                           - system-dev-sw  : Full system with a development version of SW and FW [pysmurf/rogue v4]."
+    echo "                           - system3        : Full system (stable version) [smurf2mce/rogue v3]."
+    echo "                           - system3-dev-fw : Full system (with a development version of FW) [smurf2mce/rogue v3]."
+    echo "                           - system3-dev-sw : Full system with a development version of SW and FW [smurf2mce/rogue v3]."
+    echo "                           - pysmurf-dev    : A stand-alone version of pysmurf, in development mode."
+    echo "                           - utils          : A utility system."
+    echo "                           - tpg            : A TPG IOC."
+    echo "                           - pcie           : A PCIe utility application."
+    echo "                           - atca-monitor   : An ATCA monitor application."
+    echo "  -u|--upgrade [version] : Upgrade these scripts to the specified version. If not version if specified, then the head"
+    echo "                           of the master branch will be used."
+    echo "  -l|--list-versions     : Print a list of available versions."
+    echo "  -h|--help              : Show help message for each application type."
     echo
     exit $1
 }
@@ -71,6 +79,35 @@ copy_template()
         echo ""
 }
 
+# Print a list of all available versions
+print_list_versions()
+{
+    echo "List of available versions:"
+    print_git_tags ${server_scripts_git_repo}
+    echo
+    exit 0
+}
+
+# Update these scripts
+update_scripts()
+{
+    local tag="$1"
+
+    # If not version was specified, user 'master'
+    if [ -z ${tag} ]; then
+        tag="master"
+    fi
+
+    echo "Updating these scripts to '${tag}'..."
+
+    cd ${top_dir}
+    sudo bash -c "git pull && git checkout ${tag}"
+    cd -
+
+    echo "Done!."
+    exit 0
+}
+
 #############
 # Main body #
 #############
@@ -85,6 +122,12 @@ case ${key} in
     -t|--type)
     app_type="$2"
     shift
+    ;;
+    -l|--list-versions)
+    print_list_versions
+    ;;
+    -u|--upgrade)
+    update_scripts "$2"
     ;;
     -h|--help)
     show_help=1

--- a/docker_scripts/release_atca_monitor.sh
+++ b/docker_scripts/release_atca_monitor.sh
@@ -3,7 +3,7 @@
 ###############
 # Definitions #
 ###############
-# TPG docker git repositories
+# TPG docker git repository
 atca_monitor_git_repo=https://github.com/slaclab/smurf-atca-monitor.git
 
 # Default release output directory

--- a/docker_scripts/release_atca_monitor.sh
+++ b/docker_scripts/release_atca_monitor.sh
@@ -3,6 +3,9 @@
 ###############
 # Definitions #
 ###############
+# TPG docker git repositories
+atca_monitor_git_repo=https://github.com/slaclab/smurf-atca-monitor.git
+
 # Default release output directory
 release_top_default_dir="/home/cryo/docker/atca_monitor"
 
@@ -12,6 +15,8 @@ template_dir=${template_top_dir}/atca-monitor
 ########################
 # Function definitions #
 ########################
+# Import common functions
+. common.sh
 
 # Usage message
 usage()
@@ -23,11 +28,20 @@ usage()
     echo "  -v|--version    <atca-monitor_version> : Version of the smurf-atca-monitor docker image."
     echo "  -o|--output-dir <output_dir>           : Directory where to release the scripts. Defaults to"
     echo "                                           ${release_top_default_dir}/<atca-monitor_version>"
+    echo "  -l|--list-versions                     : Print a list of available versions."
     echo "  -h|--help                              : Show this message."
     echo
     exit $1
 }
 
+# Print a list of all available versions
+print_list_versions()
+{
+    echo "List of available atca-monitor_version:"
+    print_git_tags ${atca_monitor_git_repo}
+    echo
+    exit 0
+}
 
 #############
 # Main body #
@@ -46,6 +60,9 @@ case ${key} in
     -o|--output-dir)
     target_dir="$2"
     shift
+    ;;
+    -l|--list-versions)
+    print_list_versions
     ;;
     -h|--help)
     usage 0

--- a/docker_scripts/release_pcie.sh
+++ b/docker_scripts/release_pcie.sh
@@ -3,7 +3,7 @@
 ###############
 # Definitions #
 ###############
-# PCIe docker git repositories
+# PCIe docker git repository
 pcie_git_repo=https://github.com/slaclab/smurf-pcie-docker.git
 
 # Default release output directory

--- a/docker_scripts/release_pcie.sh
+++ b/docker_scripts/release_pcie.sh
@@ -3,6 +3,9 @@
 ###############
 # Definitions #
 ###############
+# PCIe docker git repositories
+pcie_git_repo=https://github.com/slaclab/smurf-pcie-docker.git
+
 # Default release output directory
 release_top_default_dir="/home/cryo/docker/pcie"
 
@@ -12,22 +15,33 @@ template_dir=${template_top_dir}/pcie
 ########################
 # Function definitions #
 ########################
+# Import common functions
+. common.sh
 
 # Usage message
 usage()
 {
     echo "Release a PCIe utility application."
     echo
-    echo "usage: ${script_name} -t pcie -v|--version <pcie_version> [-o|--output-dir <output_dir>] [-h|--help]"
+    echo "usage: ${script_name} -t pcie -v|--version <pcie_version> [-o|--output-dir <output_dir>] [-l|--list-versions] [-h|--help]"
     echo
     echo "  -v|--version    <pcie_version> : Version of the smurf-pcie docker image."
     echo "  -o|--output-dir <output_dir>   : Directory where to release the scripts. Defaults to"
     echo "                                   ${release_top_default_dir}/<pcie_version>"
+    echo "  -l|--list-versions             : Print a list of available versions."
     echo "  -h|--help                      : Show this message."
     echo
     exit $1
 }
 
+# Print a list of all available versions
+print_list_versions()
+{
+    echo "List of available pcie_version:"
+    print_git_tags ${pcie_git_repo}
+    echo
+    exit 0
+}
 
 #############
 # Main body #
@@ -46,6 +60,9 @@ case ${key} in
     -o|--output-dir)
     target_dir="$2"
     shift
+    ;;
+    -l|--list-versions)
+    print_list_versions
     ;;
     -h|--help)
     usage 0

--- a/docker_scripts/release_pysmurf_dev.sh
+++ b/docker_scripts/release_pysmurf_dev.sh
@@ -3,6 +3,9 @@
 ###############
 # Definitions #
 ###############
+# TPG docker git repositories
+pysmurf_git_repo=https://github.com/slaclab/pysmurf.git
+
 # Default release output directory
 release_top_default_dir="/home/cryo/docker/pysmurf/dev"
 
@@ -15,6 +18,8 @@ pysmurf_git_repo=https://github.com/slaclab/pysmurf.git
 ########################
 # Function definitions #
 ########################
+# Import common functions
+. common.sh
 
 # Usage message
 usage()
@@ -30,9 +35,19 @@ usage()
     echo "                                      image; pysmurf will be overwritten by the local copy."
     echo "  -o|--output-dir <output_dir>      : Directory where to release the scripts. Defaults to"
     echo "                                      ${release_top_default_dir}"
+    echo "  -l|--list-versions                : Print a list of available versions."
     echo "  -h|--help                         : Show this message."
     echo
     exit $1
+}
+
+# Print a list of all available versions
+print_list_versions()
+{
+    echo "List of available pysmurf_version:"
+    print_git_tags ${pysmurf_git_repo}
+    echo
+    exit 0
 }
 
 #############
@@ -52,6 +67,9 @@ case ${key} in
     -o|--output-dir)
     target_dir="$2"
     shift
+    ;;
+    -l|--list-versions)
+    print_list_versions
     ;;
     -h|--help)
     usage 0

--- a/docker_scripts/release_pysmurf_dev.sh
+++ b/docker_scripts/release_pysmurf_dev.sh
@@ -3,7 +3,7 @@
 ###############
 # Definitions #
 ###############
-# TPG docker git repositories
+# pysmurf git repository
 pysmurf_git_repo=https://github.com/slaclab/pysmurf.git
 
 # Default release output directory
@@ -11,9 +11,6 @@ release_top_default_dir="/home/cryo/docker/pysmurf/dev"
 
 # Template directory for this application
 template_dir=${template_top_dir}/pysmurf-dev
-
-# pysmurf github repository
-pysmurf_git_repo=https://github.com/slaclab/pysmurf.git
 
 ########################
 # Function definitions #

--- a/docker_scripts/release_system.sh
+++ b/docker_scripts/release_system.sh
@@ -22,7 +22,6 @@ usage_header()
     echo
 }
 
-
 #############
 # Main body #
 #############

--- a/docker_scripts/release_system.sh
+++ b/docker_scripts/release_system.sh
@@ -27,7 +27,9 @@ usage_header()
 # Main body #
 #############
 
-# Call common release step to all type of application
+# Call common release step to all type of application,
+# but in this case set the "stable_release" flag.
+stable_release=1
 . system_common.sh
 
 # Print final report

--- a/docker_scripts/release_system_dev_sw.sh
+++ b/docker_scripts/release_system_dev_sw.sh
@@ -3,7 +3,10 @@
 ###############
 # Definitions #
 ###############
-# smurf2mce git repository
+# rogue git repository
+rogue_git_repo=http://github.com/slaclab/rogue.git
+
+# pysmurf git repository
 pysmurf_git_repo=http://github.com/slaclab/pysmurf.git
 
 # Prefix use in the default target release directory
@@ -19,9 +22,10 @@ usage_header()
     echo "Release a new system for SW development. Includes both server and client."
     echo "This SMuRF server is based on pysmurf and rogue v4"
     echo
-    echo "This script will clone the 'pre-release' branch of the pysmurf repository into the local directory"
-    echo "'pysmurf'. The SMuRF server docker image will use this local copy, instead of the one provided"
-    echo "internally. So, any change you make to the local copy will be present in the docker container."
+    echo "This script will clone the 'pre-release' branch of both rogue and pysmurf repositories into the local"
+    echo "directories 'rogue' and 'pysmurf' respectevely. The SMuRF server docker image will use these local copies,"
+    echo "instead of the one provided internally. So, any change you make to the local copy will be present in the"
+    echo "docker container."
     echo
     echo "The SMuRF server docker image uses an user-provided FW version, located in the local 'fw' folder."
     echo
@@ -41,14 +45,23 @@ usage_header()
 # Create fw directory
 mkdir -p ${target_dir}/fw
 
-# Clone pysmurf (master branch) in the target directory
+# Clone rogue (pre-release branch) in the target directory
+git clone ${rogue_git_repo} ${target_dir}/rogue -b pre-release
+
+# Clone pysmurf (pre-release branch) in the target directory
 git clone ${pysmurf_git_repo} ${target_dir}/pysmurf -b pre-release
 
 # Print final report
 echo ""
 echo "All Done!"
 echo "Script released to ${target_dir}"
-echo "The 'pre-release' branch of ${pysmurf_git_repo} was clone in ${target_dir}/pysmurf. That is the copy that runs inside the docker container."
+echo
+echo "The 'pre-release' branch of ${rogue_git_repo} was clone in ${target_dir}/rogue."
+echo "That is the copy that runs inside the docker container."
+echo
+echo "The 'pre-release' branch of ${pysmurf_git_repo} was clone in ${target_dir}/pysmurf."
+echo "That is the copy that runs inside the docker container."
+echo
 echo "Remember that you need to compile the pysmurf application the first time you start the container."
 echo "Remember to place your FW related files in the 'fw' directory."
 echo ""

--- a/docker_scripts/release_system_dev_sw.sh
+++ b/docker_scripts/release_system_dev_sw.sh
@@ -3,11 +3,6 @@
 ###############
 # Definitions #
 ###############
-# rogue git repository
-rogue_git_repo=http://github.com/slaclab/rogue.git
-
-# pysmurf git repository
-pysmurf_git_repo=http://github.com/slaclab/pysmurf.git
 
 # Prefix use in the default target release directory
 target_dir_prefix=dev_sw
@@ -33,7 +28,6 @@ usage_header()
     echo "and the docker image used for the client is 'tidair/pysmurf-client'."
     echo
 }
-
 
 #############
 # Main body #

--- a/docker_scripts/release_tpg.sh
+++ b/docker_scripts/release_tpg.sh
@@ -3,6 +3,9 @@
 ###############
 # Definitions #
 ###############
+# TPG docker git repositories
+tpg_git_repo=https://github.com/slaclab/smurf-tpg-ioc-docker.git
+
 # Default release output directory
 release_top_default_dir="/home/cryo/docker/tpg"
 
@@ -12,22 +15,33 @@ template_dir=${template_top_dir}/tpg
 ########################
 # Function definitions #
 ########################
+# Import common functions
+. common.sh
 
 # Usage message
 usage()
 {
     echo "Release a TPG IOC."
     echo
-    echo "usage: ${script_name} -t tpg -v|--version <tpg_version> [-o|--output-dir <output_dir>] [-h|--help]"
+    echo "usage: ${script_name} -t tpg -v|--version <tpg_version> [-o|--output-dir <output_dir>] [-l|--list-versions] [-h|--help]"
     echo
     echo "  -v|--version    <tpg_version> : Version of the smurf-tpg-ioc docker image."
     echo "  -o|--output-dir <output_dir>  : Directory where to release the scripts. Defaults to"
     echo "                                  ${release_top_default_dir}/<tpg_version>"
+    echo "  -l|--list-versions            : Print a list of available versions."
     echo "  -h|--help                     : Show this message."
     echo
     exit $1
 }
 
+# Print a list of all available versions
+print_list_versions()
+{
+    echo "List of available tpg_version:"
+    print_git_tags ${tpg_git_repo}
+    echo
+    exit 0
+}
 
 #############
 # Main body #
@@ -46,6 +60,9 @@ case ${key} in
     -o|--output-dir)
     target_dir="$2"
     shift
+    ;;
+    -l|--list-versions)
+    print_list_versions
     ;;
     -h|--help)
     usage 0

--- a/docker_scripts/release_tpg.sh
+++ b/docker_scripts/release_tpg.sh
@@ -3,7 +3,7 @@
 ###############
 # Definitions #
 ###############
-# TPG docker git repositories
+# TPG docker git repository
 tpg_git_repo=https://github.com/slaclab/smurf-tpg-ioc-docker.git
 
 # Default release output directory

--- a/docker_scripts/release_utils.sh
+++ b/docker_scripts/release_utils.sh
@@ -3,6 +3,9 @@
 ###############
 # Definitions #
 ###############
+# smurf-base docker git repositories
+smurf_base_git_repo=https://github.com/slaclab/smurf-base-docker.git
+
 # Default release output directory
 release_top_default_dir="/home/cryo/docker/utils"
 
@@ -12,22 +15,33 @@ template_dir=${template_top_dir}/utils
 ########################
 # Function definitions #
 ########################
+# Import common functions
+. common.sh
 
 # Usage message
 usage()
 {
     echo "Release an utility application."
     echo
-    echo "usage: ${script_name} -t utils -v|--version <smurf_base_version> [-o|--output-dir <output_dir>] [-h|--help]"
+    echo "usage: ${script_name} -t utils -v|--version <smurf-base_version> [-o|--output-dir <output_dir>] [-l|--list-versions] [-h|--help]"
     echo
     echo "  -v|--version    <smurf-base_version> : Version of the smurf-base docker image."
     echo "  -o|--output-dir <output_dir>         : Directory where to release the scripts. Defaults to"
     echo "                                         ${release_top_default_dir}/<smurf-base_version>"
+    echo "  -l|--list-versions                   : Print a list of available versions."
     echo "  -h|--help                            : Show this message."
     echo
     exit $1
 }
 
+# Print a list of all available versions
+print_list_versions()
+{
+    echo "List of available smurf-base_version:"
+    print_git_tags ${smurf_base_git_repo}
+    echo
+    exit 0
+}
 
 #############
 # Main body #
@@ -46,6 +60,9 @@ case ${key} in
     -o|--output-dir)
     target_dir="$2"
     shift
+    ;;
+    -l|--list-versions)
+    print_list_versions
     ;;
     -h|--help)
     usage 0

--- a/docker_scripts/release_utils.sh
+++ b/docker_scripts/release_utils.sh
@@ -3,7 +3,7 @@
 ###############
 # Definitions #
 ###############
-# smurf-base docker git repositories
+# smurf-base docker git repository
 smurf_base_git_repo=https://github.com/slaclab/smurf-base-docker.git
 
 # Default release output directory

--- a/docker_scripts/system3_common.sh
+++ b/docker_scripts/system3_common.sh
@@ -28,7 +28,7 @@ usage()
     echo "                         [-N|--slot <slot_number>] [-o|--output-dir <output_dir>] [-h|--help]"
     echo
     echo "  -s|--smurf2mce-version <smurf2mce_version> : Version of the smurf2mce docker image."
-    echo "  -p|--pysmurf_version   <pysmurf_version>   : Version of the pysmurf docker image."
+    echo "  -p|--pysmurf-version   <pysmurf_version>   : Version of the pysmurf docker image."
     echo "  -c|--comm-type         <commm_type>        : Communication type with the FPGA (eth or pcie). Defaults to 'eth'."
     echo "  -N|--slot              <slot_number>       : ATCA crate slot number (2-7) (Optional)."
     echo "  -o|--output-dir        <output_dir>        : Top directory where to release the scripts. Defaults to"
@@ -56,7 +56,7 @@ case ${key} in
     smurf2mce_version="$2"
     shift
     ;;
-    -p|--pysmurf_version)
+    -p|--pysmurf-version)
     pysmurf_version="$2"
     shift
     ;;

--- a/docker_scripts/system_common.sh
+++ b/docker_scripts/system_common.sh
@@ -18,12 +18,24 @@
 ###############
 # Definitions #
 ###############
+# Git repositories
+## rogue
+rogue_git_repo=https://github.com/slaclab/rogue.git
+
+## pysmurf
+pysmurf_git_repo=https://github.com/slaclab/pysmurf.git
+
+## pysmurf stable docker images
+pysmurf_stable_git_repo=https://github.com/slaclab/pysmurf-stable-docker.git
+
 # Default release output directory
 release_top_default_dir="/home/cryo/docker/smurf"
 
 ########################
 # Function definitions #
 ########################
+# Import common functions
+. common.sh
 
 # Usage message
 # Development releases need only 1 version, while stable
@@ -40,6 +52,7 @@ usage()
     fi
     echo "                         [-N|--slot <slot_number>]"
     echo "                         [-o|--output-dir <output_dir>]"
+    echo "                         [-l|--list-versions]"
     echo "                         [-h|--help]"
     echo
     if [ -z ${stable_release+x} ]; then
@@ -52,9 +65,31 @@ usage()
     echo "  -N|--slot           <slot_number>            : ATCA crate slot number (2-7) (Optional)."
     echo "  -o|--output-dir     <output_dir>             : Top directory where to release the scripts. Defaults to"
     echo "                                                 ${release_top_default_dir}/${target_dir_prefix}/<slot_number>/<pysmurf_version>"
+    echo "  -l|--list-versions                           : Print a list of available versions."
     echo "  -h|--help                                    : Show this message."
     echo
     exit $1
+}
+
+# Print a list of all available versions
+print_list_versions()
+{
+    if [ -z ${stable_release+x} ]; then
+        # For development releases, print pysmurf versions
+        echo "List of available pysmurf_version:"
+        print_git_tags ${pysmurf_git_repo}
+    else
+        # For stable releases, print stable pysmurf-server and pysmurf versions
+        echo "List of available pysmurf_server_version:"
+        print_git_tags ${pysmurf_stable_git_repo}
+        echo
+
+        echo "List of available pysmurf_client_version:"
+        print_git_tags ${pysmurf_git_repo}
+    fi
+
+    echo
+    exit 0
 }
 
 #############
@@ -102,6 +137,9 @@ case ${key} in
     -N|--slot)
     slot_number="$2"
     shift
+    ;;
+    -l|--list-versions)
+    print_list_versions
     ;;
     -h|--help)
     usage 0

--- a/docker_scripts/templates/common3/any-slot/docker-compose.pcie.yml
+++ b/docker_scripts/templates/common3/any-slot/docker-compose.pcie.yml
@@ -4,18 +4,24 @@ services:
   smurf_server_s2:
     devices:
     - /dev/datadev_0
+    - /dev/datadev_1
   smurf_server_s3:
     devices:
     - /dev/datadev_0
+    - /dev/datadev_1
   smurf_server_s4:
     devices:
     - /dev/datadev_0
+    - /dev/datadev_1
   smurf_server_s5:
     devices:
     - /dev/datadev_0
+    - /dev/datadev_1
   smurf_server_s6:
     devices:
     - /dev/datadev_0
+    - /dev/datadev_1
   smurf_server_s7:
     devices:
     - /dev/datadev_0
+    - /dev/datadev_1

--- a/docker_scripts/templates/common3/specific-slot/docker-compose.pcie.yml
+++ b/docker_scripts/templates/common3/specific-slot/docker-compose.pcie.yml
@@ -4,3 +4,4 @@ services:
   smurf_server_s%%SLOT_NUMBER%%:
     devices:
     - /dev/datadev_0
+    - /dev/datadev_1

--- a/docker_scripts/templates/system-dev-fw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-fw/any-slot/docker-compose.yml
@@ -19,7 +19,7 @@ x-gui-app:
 x-smurf-server:
   &smurf-server
   <<: *default-gui-app
-  image: tidair/pysmurf-server-base:%%PYSMURF_VERSION%%
+  image: tidair/pysmurf-server-base:%%SERVER_VERSION%%
   container_name: smurf_server_s${slot}
   volumes:
   - /data:/data
@@ -34,7 +34,7 @@ x-smurf-server:
 x-pysmurf:
   &pysmurf
   <<: *default-gui-app
-  image: tidair/pysmurf-client:%%PYSMURF_VERSION%%
+  image: tidair/pysmurf-client:%%CLIENT_VERSION%%
   container_name: pysmurf_s${slot}
   volumes:
   - /data:/data

--- a/docker_scripts/templates/system-dev-fw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-fw/specific-slot/docker-compose.yml
@@ -18,7 +18,7 @@ x-gui-app:
 services:
   smurf_server_s%%SLOT_NUMBER%%:
     <<: *default-gui-app
-    image: tidair/pysmurf-server-base:%%PYSMURF_VERSION%%
+    image: tidair/pysmurf-server-base:%%SERVER_VERSION%%
     container_name: smurf_server_s%%SLOT_NUMBER%%
     volumes:
     - /data:/data
@@ -30,7 +30,7 @@ services:
         tag: smurf_server
   pysmurf_s%%SLOT_NUMBER%%:
     <<: *default-gui-app
-    image: tidair/pysmurf-client:%%PYSMURF_VERSION%%
+    image: tidair/pysmurf-client:%%CLIENT_VERSION%%
     container_name: pysmurf_s%%SLOT_NUMBER%%
     volumes:
     - /data:/data

--- a/docker_scripts/templates/system-dev-sw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-sw/any-slot/docker-compose.yml
@@ -19,7 +19,7 @@ x-gui-app:
 x-smurf-server:
   &smurf-server
   <<: *default-gui-app
-  image: tidair/pysmurf-server-base:%%PYSMURF_VERSION%%
+  image: tidair/pysmurf-server-base:%%SERVER_VERSION%%
   container_name: smurf_server_s${slot}
   volumes:
   - /data:/data
@@ -36,7 +36,7 @@ x-smurf-server:
 x-pysmurf:
   &pysmurf
   <<: *default-gui-app
-  image: tidair/pysmurf-client:%%PYSMURF_VERSION%%
+  image: tidair/pysmurf-client:%%CLIENT_VERSION%%
   container_name: pysmurf_s${slot}
   volumes:
   - /data:/data

--- a/docker_scripts/templates/system-dev-sw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-sw/any-slot/docker-compose.yml
@@ -25,6 +25,7 @@ x-smurf-server:
   - /data:/data
   - /home/${user_name}:/home/${user_name}
   - ${PWD}/fw:/tmp/fw
+  - ${PWD}/rogue:/usr/local/src/rogue
   - ${PWD}/pysmurf:/usr/local/src/pysmurf
   #command: -g -w smurf_server_s${slot} -S shm-smrf-sp01 -N ${slot} -e smurf_server_s${slot} %%COMM_ARGS%% -d /tmp/fw/config/defaults.yml ${extra_opts}
   entrypoint: bash

--- a/docker_scripts/templates/system-dev-sw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-sw/specific-slot/docker-compose.yml
@@ -18,7 +18,7 @@ x-gui-app:
 services:
   smurf_server_s%%SLOT_NUMBER%%:
     <<: *default-gui-app
-    image: tidair/pysmurf-server-base:%%PYSMURF_VERSION%%
+    image: tidair/pysmurf-server-base:%%SERVER_VERSION%%
     container_name: smurf_server_s%%SLOT_NUMBER%%
     volumes:
     - /data:/data
@@ -32,7 +32,7 @@ services:
         tag: smurf_server
   pysmurf_s%%SLOT_NUMBER%%:
     <<: *default-gui-app
-    image: tidair/pysmurf-client:%%PYSMURF_VERSION%%
+    image: tidair/pysmurf-client:%%CLIENT_VERSION%%
     container_name: pysmurf_s%%SLOT_NUMBER%%
     volumes:
     - /data:/data

--- a/docker_scripts/templates/system-dev-sw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-sw/specific-slot/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     - /data:/data
     - /home/${user_name}:/home/${user_name}
     - ${PWD}/fw:/tmp/fw
+    - ${PWD}/rogue:/usr/local/src/rogue
     - ${PWD}/pysmurf:/usr/local/src/pysmurf
     #command: -g -w smurf_server_s%%SLOT_NUMBER%% -S shm-smrf-sp01 -N %%SLOT_NUMBER%% -e smurf_server_s%%SLOT_NUMBER%% %%COMM_ARGS%% -d /tmp/fw/config/defaults.yml ${extra_opts}
     entrypoint: bash

--- a/docker_scripts/templates/system/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system/any-slot/docker-compose.yml
@@ -22,7 +22,7 @@ x-gui-app:
 x-smurf-server:
   &smurf-server
   <<: *default-gui-app
-  image: tidair/pysmurf-server:%%PYSMURF_VERSION%%
+  image: tidair/pysmurf-server:%%SERVER_VERSION%%
   container_name: smurf_server_s${slot}
   command: -w smurf_server_s${slot} -S shm-smrf-sp01 -N ${slot} -e smurf_server_s${slot} %%COMM_ARGS%% ${extra_opts}
   logging:
@@ -33,7 +33,7 @@ x-smurf-server:
 x-pysmurf:
   &pysmurf
   <<: *default-gui-app
-  image: tidair/pysmurf-client:%%PYSMURF_VERSION%%
+  image: tidair/pysmurf-client:%%CLIENT_VERSION%%
   container_name: pysmurf_s${slot}
   command: --epics smurf_server_s${slot}
   logging:

--- a/docker_scripts/templates/system/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system/specific-slot/docker-compose.yml
@@ -21,7 +21,7 @@ x-gui-app:
 services:
   smurf_server_s%%SLOT_NUMBER%%:
     <<: *default-gui-app
-    image: tidair/pysmurf-server:%%PYSMURF_VERSION%%
+    image: tidair/pysmurf-server:%%SERVER_VERSION%%
     container_name: smurf_server_s%%SLOT_NUMBER%%
     command: -w smurf_server_s%%SLOT_NUMBER%% -S shm-smrf-sp01 -N %%SLOT_NUMBER%% -e smurf_server_s%%SLOT_NUMBER%% %%COMM_ARGS%% ${extra_opts}
     logging:
@@ -29,7 +29,7 @@ services:
         tag: smurf_server
   pysmurf_s%%SLOT_NUMBER%%:
     <<: *default-gui-app
-    image: tidair/pysmurf-client:%%PYSMURF_VERSION%%
+    image: tidair/pysmurf-client:%%CLIENT_VERSION%%
     container_name: pysmurf_s%%SLOT_NUMBER%%
     command: --epics smurf_server_s%%SLOT_NUMBER%%
     logging:


### PR DESCRIPTION
- Update docker-compose.pcie.yml templates to include both devices, for system3*,
- Bug fix: When releasing an stable system, the user need to specified both the version of the pysmurf-server and of the pysmurf-client docker images, as they come from different repositories, with different tags,
- When releasing a software development system, also use a local copy of rogue,
- Add option to all script to list all the available versions,
- Add option to the top `release-docker.sh` script to updated its version.