### PR TITLE
Remove the default argument "-d /tmp/fw/config/defaults.yml" from

### DIFF
--- a/docker_scripts/templates/system-dev-fw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-fw/any-slot/docker-compose.yml
@@ -26,7 +26,7 @@ x-smurf-server:
   - /home/${user_name}/.Xauthority:/home/${user_name}/.Xauthority
   - /home/${user_name}/.bash_history:/home/${user_name}/.bash_history
   - ${PWD}/fw:/tmp/fw
-  command: -g -w smurf_server_s${slot} -S shm-smrf-sp01 -N ${slot} -e smurf_server_s${slot} %%COMM_ARGS%% -d /tmp/fw/config/defaults.yml ${extra_opts}
+  command: -g -w smurf_server_s${slot} -S shm-smrf-sp01 -N ${slot} -e smurf_server_s${slot} %%COMM_ARGS%% ${extra_opts}
   logging:
     options:
       tag: smurf_server

--- a/docker_scripts/templates/system-dev-fw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-fw/specific-slot/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     - /home/${user_name}/.Xauthority:/home/${user_name}/.Xauthority
     - /home/${user_name}/.bash_history:/home/${user_name}/.bash_history
     - ${PWD}/fw:/tmp/fw
-    command: -g -w smurf_server_s%%SLOT_NUMBER%% -S shm-smrf-sp01 -N %%SLOT_NUMBER%% -e smurf_server_s%%SLOT_NUMBER%% %%COMM_ARGS%% -d /tmp/fw/config/defaults.yml ${extra_opts}
+    command: -g -w smurf_server_s%%SLOT_NUMBER%% -S shm-smrf-sp01 -N %%SLOT_NUMBER%% -e smurf_server_s%%SLOT_NUMBER%% %%COMM_ARGS%% ${extra_opts}
     logging:
       options:
         tag: smurf_server

--- a/docker_scripts/templates/system-dev-sw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-sw/any-slot/docker-compose.yml
@@ -28,7 +28,7 @@ x-smurf-server:
   - ${PWD}/fw:/tmp/fw
   - ${PWD}/rogue:/usr/local/src/rogue
   - ${PWD}/pysmurf:/usr/local/src/pysmurf
-  command: -g -w smurf_server_s${slot} -S shm-smrf-sp01 -N ${slot} -e smurf_server_s${slot} %%COMM_ARGS%% -d /tmp/fw/config/defaults.yml ${extra_opts}
+  command: -g -w smurf_server_s${slot} -S shm-smrf-sp01 -N ${slot} -e smurf_server_s${slot} %%COMM_ARGS%% ${extra_opts}
   #entrypoint: bash
   logging:
     options:

--- a/docker_scripts/templates/system-dev-sw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-sw/specific-slot/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     - ${PWD}/fw:/tmp/fw
     - ${PWD}/rogue:/usr/local/src/rogue
     - ${PWD}/pysmurf:/usr/local/src/pysmurf
-    command: -g -w smurf_server_s%%SLOT_NUMBER%% -S shm-smrf-sp01 -N %%SLOT_NUMBER%% -e smurf_server_s%%SLOT_NUMBER%% %%COMM_ARGS%% -d /tmp/fw/config/defaults.yml ${extra_opts}
+    command: -g -w smurf_server_s%%SLOT_NUMBER%% -S shm-smrf-sp01 -N %%SLOT_NUMBER%% -e smurf_server_s%%SLOT_NUMBER%% %%COMM_ARGS%% ${extra_opts}
     #entrypoint: bash
     logging:
       options:


### PR DESCRIPTION
the docker-compose.yml as it will be now auto-generated by the
start_server.sh script. 

Also, that default values was never used anyways, it was always changed by the user after releasing a set of scripts.

https://jira.slac.stanford.edu/browse/ESCRYODET-602
