### PR TITLE
Fix version listed for the release-docker.sh script and the guis app

### DIFF
--- a/docker_scripts/README.md
+++ b/docker_scripts/README.md
@@ -372,7 +372,7 @@ release-docker.sh -t atca-monitor -v|--version <atca-monitor_version> [-o|--outp
 
 An application to connect a rogue GUI to a remote server.
 
-It runs in the [smurf-rogue docker](https://github.com/slaclab/smurf-rogue-docker).
+It runs in the [smurf-rogue docker](https://github.com/slaclab/smurf-rogue-docker). This docker images included support for this application starting in version [R2.7.0](https://github.com/slaclab/smurf-rogue-docker/releases/tag/R2.7.0).
 
 To release this application use **type = guis**, with the following argument:
 ```

--- a/docker_scripts/release-docker.sh
+++ b/docker_scripts/release-docker.sh
@@ -83,8 +83,10 @@ copy_template()
 # Print a list of all available versions
 print_list_versions()
 {
+    # The version list and upgrade feature was added in version R3.1.0,
+    # so exclude previous versions.
     echo "List of available versions of this script:"
-    print_git_tags ${server_scripts_git_repo}
+    print_git_tags ${server_scripts_git_repo} 'R1.\|R2.\|R3.0'
     echo
     exit 0
 }
@@ -101,6 +103,15 @@ update_scripts()
         echo "Not tag was specified, so updating these scripts to the head of the master branch..."
         sudo bash -c "git fetch --all --tags && git checkout master && git pull"
     else
+
+        # Check if the version exist
+        ret=$(verify_git_tag_exist ${server_scripts_git_repo} ${tag} 'R1.\|R2.\|R3.0')
+        if [ -z ${ret} ]; then
+            echo "ERROR: version ${tag} does not exist"
+            echo "You can use the '-l' option to list the available versions."
+            echo
+            exit 1
+        fi
         echo "Updating these scripts to version '${tag}'..."
         sudo bash -c "git fetch --all --tags && git checkout ${tag}"
     fi

--- a/docker_scripts/release_guis.sh
+++ b/docker_scripts/release_guis.sh
@@ -85,7 +85,7 @@ if [ -z ${smurf_rogue_version+x} ]; then
 fi
 
 # Check if the smurf-rogue version exist
-ret=$(verify_git_tag_exist ${smurf_rogue_git_repo} ${smurf_rogue_version})
+ret=$(verify_git_tag_exist ${smurf_rogue_git_repo} ${smurf_rogue_version} 'R0.\|R1.\|R2.0.\|R2.1\|R2.2\|R2.3\|R2.4\|R2.5\|R2.6')
 if [ -z ${ret} ]; then
     echo "ERROR: smurf-rogue version ${smurf_rogue_version} does not exist"
     echo "You can use the '-l' option to list the available versions."

--- a/docker_scripts/release_guis.sh
+++ b/docker_scripts/release_guis.sh
@@ -38,8 +38,9 @@ usage()
 # Print a list of all available versions
 print_list_versions()
 {
+    # This application type is supported starting at version R2.7.0, so exclude all previous versions
     echo "List of available smurf-rogue_version:"
-    print_git_tags ${smurf_rogue_git_repo}
+    print_git_tags ${smurf_rogue_git_repo} 'R0.\|R1.\|R2.0.\|R2.1\|R2.2\|R2.3\|R2.4\|R2.5\|R2.6'
     echo
     exit 0
 }


### PR DESCRIPTION
For the `release-docker.sh` script version list, exclude version previous to `R3.1.0`, as those version didn't support the list nor the upgrade options, so it would be able to go back to a new version after changeing it.
For the guis application type, exclude the smurf-rogue version previous to version `R2.7.0`, as those version didn't support to attach GUIs.