### PR TITLE
Install the PCIe `datadev` kernel driver as a DKMS package

### DIFF
--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -425,7 +425,7 @@ if [ ${dell_r440+x} ]; then
     datadev_name=datadev
 
     # Driver version
-    datadev_version=5.8.9
+    datadev_version=v5.7.0
 
     # Check if version exist in the repository
     if ! git ls-remote --refs --tag ${datadev_repo} | grep -q refs/tags/${datadev_version} > /dev/null ; then

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -502,8 +502,6 @@ EOF
                 if [ $? -ne 0 ]; then
                     echo "ERROR: failed to load the module"
                 else
-                    echo "The driver was installed and loaded successfully"
-
                     # Remove the now legacy call to 'install_module.sh' in /etc/profile.d/smurf_config.sh
                     # and sudoers files.
                     sed -i -e '/.*\/usr\/local\/src\/datadev\/.*\/install-module.sh/d' /etc/profile.d/smurf_config.sh
@@ -514,6 +512,8 @@ EOF
                     cat << EOF >> /etc/sysctl.conf
 vm.max_map_count=262144
 EOF
+
+                    echo "The driver was installed and loaded successfully"
                 fi
             fi
         fi

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -508,6 +508,12 @@ EOF
                     # and sudoers files.
                     sed -i -e '/.*\/usr\/local\/src\/datadev\/.*\/install-module.sh/d' /etc/profile.d/smurf_config.sh
                     sed -i -e '/.*\/usr\/local\/src\/datadev\/.*\/install-module.sh/d' /etc/sudoers
+
+                    # Change the default virtual memory mmap count limits
+                    sed -i -e '/^vm.max_map_count=.*/d' /etc/sysctl.conf
+                    cat << EOF >> /etc/sysctl.conf
+vm.max_map_count=262144
+EOF
                 fi
             fi
         fi

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -502,8 +502,12 @@ EOF
                 if [ $? -ne 0 ]; then
                     echo "ERROR: failed to load the module"
                 else
-
                     echo "The driver was installed and loaded successfully"
+
+                    # Remove the now legacy call to 'install_module.sh' in /etc/profile.d/smurf_config.sh
+                    # and sudoers files.
+                    sed -i -e '/.*\/usr\/local\/src\/datadev\/.*\/install-module.sh/d' /etc/profile.d/smurf_config.sh
+                    sed -i -e '/.*\/usr\/local\/src\/datadev\/.*\/install-module.sh/d' /etc/sudoers
                 fi
             fi
         fi

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -474,7 +474,7 @@ if [ ${dell_r440+x} ]; then
 options ${datadev_name} cfgTxCount=1024 cfgRxCount=1024 cfgSize=131072 cfgMode=1 cfgCont=1
 EOF
             cat << EOF > /usr/src/${datadev_name}-${datadev_version}/dkms.conf
-MAKE="makei -C aes-stream-drivers/data_dev/driver/"
+MAKE="make -C aes-stream-drivers/data_dev/driver/"
 CLEAN="make -C aes-stream-drivers/data_dev/driver/ clean"
 BUILT_MODULE_NAME=${datadev_name}
 BUILT_MODULE_LOCATION=aes-stream-drivers/data_dev/driver/

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -60,7 +60,8 @@ apt-get -y install \
     tigervnc-standalone-server \
     tigervnc-viewer \
     xfce4 \
-    xfce4-goodies
+    xfce4-goodies \
+    dkms
 
 # Install it lfs
 curl -fsSL --retry-connrefused --retry 5 https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash


### PR DESCRIPTION
Install the PCIe kernel driver (datadev) as a DKMS so that kernel updates will also update the driver automatically. 

Also, cleanup the previous (now legacy) way of installing and loading the module. In this way, if this script is run in an old server it will update the driver correctly. 

Finally, update the version of the driver to out current version `v5.7.0`.

This PR solves:
https://jira.slac.stanford.edu/browse/ESCRYODET-594
https://jira.slac.stanford.edu/browse/ESCRYODET-746