### PR TITLE
Save the version of the setup script used to setup the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Where `<VERSION>` is the version of this script you want to use.
 
 A list of available versions, with release notes described the changes on each version, can be found in the releases section of this repository [here](https://github.com/slaclab/smurf-server-scripts/releases).
 
+To see the version of the script used to configured your system, run this command:
+```bash
+$ smurf-server-scripts-version
+```
+
+**Note**: if the command `smurf-server-scripts-version` does not exist in your system, then you server was setup with a script version previous to `R3.8.0`.
+
 ## Docker System Release Scripts
 
 As part of the system initialization described above, scripts to release SMuRF docker-based systems are installed in the server. For more information about these scripts, please refer to [this documentation](docker_scripts/README.md).

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -76,6 +76,13 @@ curl -fsSL --retry-connrefused --retry 5 https://packagecloud.io/install/reposit
 apt-get -y install git-lfs
 git lfs install
 
+# Save the version of the script used during this setup:
+version_file="version"
+rm -f ${version_file}
+touch ${version_file}
+chown -R cryo:smurf ${version_file}
+git describe --tags --always > ${version_file} 2> /dev/null
+
 # Install this server scripts into the system
 rm -rf /usr/local/src/smurf-server-scripts
 mkdir -p /usr/local/src/smurf-server-scripts
@@ -84,6 +91,12 @@ cp -r .. /usr/local/src/smurf-server-scripts
 # Create smurf bash profile file and add the docker scripts to PATH
 if ! grep -Fq "export PATH=\${PATH}:/usr/local/src/smurf-server-scripts/docker_scripts" /etc/profile.d/smurf_config.sh 2> /dev/null; then
     echo "export PATH=\${PATH}:/usr/local/src/smurf-server-scripts/docker_scripts" >> /etc/profile.d/smurf_config.sh
+fi
+
+# Add an alias 'smurf-server-scripts-version' to the smurf bash profile file, to get the version of the smurf-server-script
+# used during this setup
+if ! grep -q "^alias smurf-server-scripts-version='cat /usr/local/src/smurf-server-scripts/server_scripts/version'\s*" /etc/profile.d/smurf_config.sh 2> /dev/null; then
+    echo "alias smurf-server-scripts-version='cat /usr/local/src/smurf-server-scripts/server_scripts/version'" >> /etc/profile.d/smurf_config.sh
 fi
 
 # Disable automatic system updates

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -89,13 +89,13 @@ mkdir -p /usr/local/src/smurf-server-scripts
 cp -r .. /usr/local/src/smurf-server-scripts
 
 # Create smurf bash profile file and add the docker scripts to PATH
-if ! grep -Fq "export PATH=\${PATH}:/usr/local/src/smurf-server-scripts/docker_scripts" /etc/profile.d/smurf_config.sh 2> /dev/null; then
+if ! grep -q "^export PATH=\${PATH}:/usr/local/src/smurf-server-scripts/docker_scripts\s*$" /etc/profile.d/smurf_config.sh 2> /dev/null; then
     echo "export PATH=\${PATH}:/usr/local/src/smurf-server-scripts/docker_scripts" >> /etc/profile.d/smurf_config.sh
 fi
 
 # Add an alias 'smurf-server-scripts-version' to the smurf bash profile file, to get the version of the smurf-server-script
 # used during this setup
-if ! grep -q "^alias smurf-server-scripts-version='cat /usr/local/src/smurf-server-scripts/server_scripts/version'\s*" /etc/profile.d/smurf_config.sh 2> /dev/null; then
+if ! grep -q "^alias smurf-server-scripts-version='cat /usr/local/src/smurf-server-scripts/server_scripts/version'\s*$" /etc/profile.d/smurf_config.sh 2> /dev/null; then
     echo "alias smurf-server-scripts-version='cat /usr/local/src/smurf-server-scripts/server_scripts/version'" >> /etc/profile.d/smurf_config.sh
 fi
 


### PR DESCRIPTION
This PR add, makes the `setup-server.sh` to save the version of the script used to setup the server in the file `/usr/local/src/smurf-server-scripts/server_scripts/version`. 

Also, a convenient alias called `smurf-server-scripts-version` is added to the SMuRF profile file (`/etc/profile.d/smurf_config.sh`) to retire this version number, for example
```bash
cryo@smurf-srv19:~$ smurf-server-scripts-version
R3.7.0-24-gc4523bd
```