### PR TITLE
Bug fix: Add the KERNELDIR variable to the `datadev` DKMS file

### DIFF
--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -535,7 +535,7 @@ if [ ${dell_r440+x} ]; then
 options ${datadev_name} cfgTxCount=1024 cfgRxCount=1024 cfgSize=131072 cfgMode=1 cfgCont=1
 EOF
             cat << EOF > /usr/src/${datadev_name}-${datadev_version}/dkms.conf
-MAKE="make -C aes-stream-drivers/data_dev/driver/"
+MAKE="make -C aes-stream-drivers/data_dev/driver/ KERNELDIR=/lib/modules/\${kernelver}/build"
 CLEAN="make -C aes-stream-drivers/data_dev/driver/ clean"
 BUILT_MODULE_NAME=${datadev_name}
 BUILT_MODULE_LOCATION=aes-stream-drivers/data_dev/driver/

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -539,10 +539,10 @@ MAKE="make -C aes-stream-drivers/data_dev/driver/ KERNELDIR=/lib/modules/\${kern
 CLEAN="make -C aes-stream-drivers/data_dev/driver/ clean"
 BUILT_MODULE_NAME=${datadev_name}
 BUILT_MODULE_LOCATION=aes-stream-drivers/data_dev/driver/
-DEST_MODULE_LOCATION="/kernel/modules/misc"
+DEST_MODULE_LOCATION=/kernel/modules/misc
 PACKAGE_NAME=${datadev_name}
 REMAKE_INITRD=no
-AUTOINSTALL="yes"
+AUTOINSTALL=yes
 PACKAGE_VERSION=${datadev_version}
 EOF
 


### PR DESCRIPTION
Defining the `KERNELDIR` environmental variable was missing from the `datadev`'s DKMS setup file, on the `MAKE` command. This was building the kernel module for the currently running kernel version during a system upgrade.