### PR TITLE
Set env var `EPICS_CA_AUTO_ADDR_LIST=NO` by default

### DIFF
--- a/docker_scripts/templates/pysmurf-dev/run.sh
+++ b/docker_scripts/templates/pysmurf-dev/run.sh
@@ -9,6 +9,7 @@ docker run -it --rm  \
   --net host \
   -e DISPLAY \
   -e location=${PWD} \
+  -e EPICS_CA_AUTO_ADDR_LIST=NO \
   -e EPICS_CA_ADDR_LIST=127.255.255.255 \
   -e EPICS_CA_MAX_ARRAY_BYTES=80000000 \
   -v /home/${user}/.Xauthority:/home/${user}/.Xauthority \

--- a/docker_scripts/templates/system-dev-fw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-fw/any-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   security_opt:

--- a/docker_scripts/templates/system-dev-fw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-fw/specific-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   security_opt:

--- a/docker_scripts/templates/system-dev-sw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-sw/any-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   security_opt:

--- a/docker_scripts/templates/system-dev-sw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system-dev-sw/specific-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   security_opt:

--- a/docker_scripts/templates/system/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system/any-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   volumes:

--- a/docker_scripts/templates/system/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system/specific-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   volumes:

--- a/docker_scripts/templates/system3-dev-fw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system3-dev-fw/any-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   security_opt:

--- a/docker_scripts/templates/system3-dev-fw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system3-dev-fw/specific-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   security_opt:

--- a/docker_scripts/templates/system3-dev-sw/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system3-dev-sw/any-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   security_opt:

--- a/docker_scripts/templates/system3-dev-sw/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system3-dev-sw/specific-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   security_opt:

--- a/docker_scripts/templates/system3/any-slot/docker-compose.yml
+++ b/docker_scripts/templates/system3/any-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   volumes:

--- a/docker_scripts/templates/system3/specific-slot/docker-compose.yml
+++ b/docker_scripts/templates/system3/specific-slot/docker-compose.yml
@@ -8,6 +8,7 @@ x-gui-app:
   environment:
   - location=${PWD}
   - DISPLAY
+  - EPICS_CA_AUTO_ADDR_LIST=NO
   - EPICS_CA_ADDR_LIST=127.255.255.255
   - EPICS_CA_MAX_ARRAY_BYTES=80000000
   volumes:

--- a/docker_scripts/templates/tpg/docker-compose.yml
+++ b/docker_scripts/templates/tpg/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     network_mode: "host"
     environment:
     - location=${PWD}
+    - EPICS_CA_AUTO_ADDR_LIST=NO
     - EPICS_CA_ADDR_LIST=127.255.255.255
     security_opt:
     - "apparmor=docker-smurf"


### PR DESCRIPTION
This will set the EPICS CA network to the local host, by default. Otherwise, by default, the EPICS CA will use all present interfaces in the host, which could create issue in institutions where the host CPU is constantly connected and disconnected from networks, like the issue describe in: https://jira.slac.stanford.edu/browse/ESCRYODET-773