### PR TITLE
Install `shwanhammer` scripts

### DIFF
--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -610,7 +610,7 @@ shawnhammer_scripts_location="/home/cryo/docker/pysmurf/dev/${pysmurf_dev_versio
 for s in ${shawnhammer_scripts[@]}; do
     ln -s ${shawnhammer_scripts_location}/${s}.sh ${new_script_path}/${s} &> /dev/null && \
         chown -fR cryo:smurf ${new_script_path}/${s} && \
-        echo "\"${s}\" created, pointing to \"${shawnhammer_scripts_location}/${s}.sh\""
+        echo "\"${s}\" was created, pointing to \"${shawnhammer_scripts_location}/${s}.sh\""
 done
 
 echo "###########################################"

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -610,7 +610,7 @@ shawnhammer_scripts_location="/home/cryo/docker/pysmurf/dev/${pysmurf_dev_versio
 for s in ${shawnhammer_scripts[@]}; do
     ln -s ${shawnhammer_scripts_location}/${s}.sh ${new_script_path}/${s} &> /dev/null && \
         chown -fR cryo:smurf ${new_script_path}/${s} && \
-        echo "\"${s}\" created."
+        echo "\"${s}\" created, pointing to \"${shawnhammer_scripts_location}/${s}.sh\""
 done
 
 echo "###########################################"

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -83,11 +83,6 @@ touch ${version_file}
 chown -R cryo:smurf ${version_file}
 git describe --tags --always > ${version_file} 2> /dev/null
 
-# Install this server scripts into the system
-rm -rf /usr/local/src/smurf-server-scripts
-mkdir -p /usr/local/src/smurf-server-scripts
-cp -r .. /usr/local/src/smurf-server-scripts
-
 # Create smurf bash profile file and add the docker scripts to PATH
 if ! grep -q "^export PATH=\${PATH}:/usr/local/src/smurf-server-scripts/docker_scripts\s*$" /etc/profile.d/smurf_config.sh 2> /dev/null; then
     echo "export PATH=\${PATH}:/usr/local/src/smurf-server-scripts/docker_scripts" >> /etc/profile.d/smurf_config.sh
@@ -575,9 +570,9 @@ done
 # Move back to the original directory
 cd - &> /dev/null
 
-echo "########################################"
-echo "### Done releasing docker scripts... ###"
-echo "########################################"
+echo "######################################"
+echo "### Done releasing docker scripts. ###"
+echo "######################################"
 
 #######################
 # RELEASE SHAWNHAMMER #
@@ -613,13 +608,32 @@ cd - &> /dev/null
 shawnhammer_scripts_location="/home/cryo/docker/pysmurf/dev/${pysmurf_dev_version}/pysmurf/scratch/shawn/scripts"
 for s in ${shawnhammer_scripts[@]}; do
     ln -s ${shawnhammer_scripts_location}/${s}.sh ${new_script_path}/${s} &> /dev/null && \
-        chown -fR cryo:smurf ${new_script_path}/${s}
+        chown -fR cryo:smurf ${new_script_path}/${s} &&
+        echo "\"${s}\" created."
 done
 
-echo "#############################################"
-echo "### Done releasing shawnhammer scripts... ###"
-echo "#############################################"
+echo "###########################################"
+echo "### Done releasing shawnhammer scripts. ###"
+echo "###########################################"
 
+#########################################
+# INSTALL THESE SCRIPTS INTO THE SYSTEM #
+#########################################
+
+# NOTE: We need to install these scripts, after installing
+# shawnhammer scripts, to avoid overriding existing versions
+
+echo "###################################################"
+echo "### Installing these scripts into the system... ###"
+echo "###################################################"
+
+rm -rf /usr/local/src/smurf-server-scripts
+mkdir -p /usr/local/src/smurf-server-scripts
+cp -r .. /usr/local/src/smurf-server-scripts
+
+echo "######################################################"
+echo "### Done installing these scripts into the system. ###"
+echo "######################################################"
 
 ######################
 # SHOW FINAL MESSAGE #

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -591,7 +591,8 @@ old_script_path='/usr/local/src/smurf-server-scripts/docker_scripts'
 new_script_path='/home/cryo/.local/bin'
 for s in ${shawnhammer_scripts[@]}; do
     mv ${old_script_path}/${s} ${new_script_path}/${s} &> /dev/null && \
-        chown -fR cryo:smurf ${new_script_path}/${s}
+        chown -fR cryo:smurf ${new_script_path}/${s} && \
+        echo "\"${s}\" was found under \"${old_script_path}/\". It was moved to \"${new_script_path}/\"."
 done
 
 # Get the latest version of pysmurf-dev. This version was either,
@@ -608,7 +609,7 @@ cd - &> /dev/null
 shawnhammer_scripts_location="/home/cryo/docker/pysmurf/dev/${pysmurf_dev_version}/pysmurf/scratch/shawn/scripts"
 for s in ${shawnhammer_scripts[@]}; do
     ln -s ${shawnhammer_scripts_location}/${s}.sh ${new_script_path}/${s} &> /dev/null && \
-        chown -fR cryo:smurf ${new_script_path}/${s} &&
+        chown -fR cryo:smurf ${new_script_path}/${s} && \
         echo "\"${s}\" created."
 done
 

--- a/server_scripts/setup-server.sh
+++ b/server_scripts/setup-server.sh
@@ -563,20 +563,63 @@ echo "###################################"
 # Move to the docker_script directory
 cd ../docker_scripts
 
-# Release latest utils, atca-monitor, guis, and pcie dockers. We need to release
-# them as the 'cryo' user so that the generated files has the right permissions.
-for d in 'utils' 'pcie' 'atca-monitor' 'guis' ; do
+# Release latest pysmurf-dev, utils, atca-monitor, guis, and pcie dockers.
+# We need to release them as the 'cryo' user so that the generated files
+# has the right permissions.
+for d in 'utils' 'pcie' 'atca-monitor' 'guis' 'pysmurf-dev'; do
     v=$(./release-docker.sh -t ${d} -l | tail -n2 | head -n1)
     echo "Releasing '${d}' version '${v}'..."
     su cryo -c "./release-docker.sh -t ${d} -v ${v}"
 done
 
 # Move back to the original directory
-cd -
+cd - &> /dev/null
 
 echo "########################################"
 echo "### Done releasing docker scripts... ###"
 echo "########################################"
+
+#######################
+# RELEASE SHAWNHAMMER #
+#######################
+echo "########################################"
+echo "### Releasing shawnhammer scripts... ###"
+echo "########################################"
+
+# List of shawnhammer scripts
+shawnhammer_scripts=('ping_carrier' 'shawnhammer' 'shawnhammerfunctions' 'switch_carrier')
+
+# First, move soft links defined, if any, under
+# "/usr/local/src/smurf-server-scripts/docker_scripts/"
+# to the standard location "/home/cryo/.local/bin"
+old_script_path='/usr/local/src/smurf-server-scripts/docker_scripts'
+new_script_path='/home/cryo/.local/bin'
+for s in ${shawnhammer_scripts[@]}; do
+    mv ${old_script_path}/${s} ${new_script_path}/${s} &> /dev/null && \
+        chown -fR cryo:smurf ${new_script_path}/${s}
+done
+
+# Get the latest version of pysmurf-dev. This version was either,
+# released, or already existed.
+cd ../docker_scripts
+pysmurf_dev_version=$(./release-docker.sh -t pysmurf-dev -l | tail -n2 | head -n1)
+cd - &> /dev/null
+
+# Now create, new soft links.
+# They will be created in the standard location "/home/cryo/.local/bin"
+# and will point to the latest pysmurf-dev version.=, which was
+# either released or already existed.
+# If the soft links already exist, they won't be overridden.
+shawnhammer_scripts_location="/home/cryo/docker/pysmurf/dev/${pysmurf_dev_version}/pysmurf/scratch/shawn/scripts"
+for s in ${shawnhammer_scripts[@]}; do
+    ln -s ${shawnhammer_scripts_location}/${s}.sh ${new_script_path}/${s} &> /dev/null && \
+        chown -fR cryo:smurf ${new_script_path}/${s}
+done
+
+echo "#############################################"
+echo "### Done releasing shawnhammer scripts... ###"
+echo "#############################################"
+
 
 ######################
 # SHOW FINAL MESSAGE #


### PR DESCRIPTION
Install `shawnhammer` scripts as part of the server setup. They will be install under a new standard location: `/home/cryo/.local/bin/`. The scripts are:
- `ping_carrier`,
- `shawnhammer`, 
- `shawnhammerfunctions`, and
- `switch_carrier`.

and they will point to the latest version `pysmurf-dev`. This version either, is installed as part of the server script, or it is already present in the server (if it is already present, it is not modified).

Already existing soft-links, created under `/usr/local/src/smurf-server-scripts/docker_scripts/` are moved to `/home/cryo/.local/bin/`, without changing their target.

Already existing soft-links, under `/home/cryo/.local/bin/` are not modified.

This PR also add `pysmurf-dev` to the list of docker scripts which is released, using the latest version, by default by the server script. 

https://jira.slac.stanford.edu/browse/ESCRYODET-781

